### PR TITLE
Adding history support

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,21 @@
+[
+    // For history navigation.
+    {
+        "keys": ["up"], "command": "sublime_external_command_history",
+        "args": {
+            "backwards": true
+        },
+        "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.external_command" }
+        ]
+    },
+    {
+        "keys": ["down"], "command": "sublime_external_command_history",
+        "context":
+        [
+            { "key": "selector", "operator": "equal", "operand": "text.external_command" }
+        ]
+
+    }
+]

--- a/external_command.hidden-tmLanguage
+++ b/external_command.hidden-tmLanguage
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Used to give a "scope" for the input box. -->
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>SublimeExternalCommandInputPanel</string>
+    <key>scopeName</key>
+    <string>text.external_command</string>
+    <key>uuid</key>
+    <string>600146c3-8aa7-4940-b5da-8d7b67a6a0e1</string>
+</dict>
+</plist>

--- a/external_command.py
+++ b/external_command.py
@@ -293,6 +293,7 @@ class ExternalCommandBase(sublime_plugin.TextCommand):
                 start(cmdline)
             else:
                 panel = self.view.window().show_input_panel('Command:', history.getLast(), start, None, None)
+                # This sets a scope to the input panel, which enables the history navigation commands.
                 panel.set_syntax_file('Packages/SublimeExternalCommand/external_command.hidden-tmLanguage')
                 panel.settings().set('is_widget', True)
                 panel.settings().set('gutter', False)

--- a/external_command.py
+++ b/external_command.py
@@ -1,4 +1,72 @@
-import sublime, sublime_plugin, subprocess, _thread, re, os
+import sublime, sublime_plugin, subprocess, _thread, re, os, io
+
+HISTORY_SIZE = 16
+HISTORY_FILENAME = '~/.sublimeexternalcommand_history'
+
+class History:
+    '''
+    Command history management.
+    '''
+    def __init__(self, max_size, filename):
+        self.max_size = max_size
+        self.filename = os.path.expanduser(filename)
+
+    def read(self):
+        '''Read all commands from the history file and return as a list.'''
+        commands = []
+        if os.path.isfile(self.filename):
+            f = io.open(self.filename, 'r', encoding='utf-8')
+            commands = list(map(lambda s: s.strip(), f.readlines()))
+            f.close()
+        return commands
+
+    def size(self):
+        '''Return the number of commands in the history file.'''
+        return len(self.read())
+
+    def write(self, commands):
+        '''Write commands to the history file.'''
+        if len(commands) > self.max_size:
+            commands = commands[0:self.max_size]
+
+        f = io.open(self.filename, 'w', encoding='utf-8')
+        f.write('\n'.join(commands))
+        f.close()
+
+    def add(self, command):
+        '''Add a command to the history file.'''
+        command = command.strip()
+        # If the same command is in the history, remove it first.
+        commands = list(filter(lambda s: s != command, self.read()))
+        commands.insert(0, command)
+        self.write(commands)
+
+    def getLast(self):
+        '''Return the most recent command.'''
+        commands = self.read()
+        if len(commands) > 0:
+            return commands[0]
+        else:
+            return ''
+
+history = History(HISTORY_SIZE, HISTORY_FILENAME)
+
+class SublimeExternalCommandHistory(sublime_plugin.TextCommand):
+    '''
+    Handles the UP/DOWN keys in the command input box.
+    '''
+    index = 0
+
+    def run(self, edit, backwards=False):
+        # sublime.status_message('History %d -> %s [%d]' % (SublimeExternalCommandHistory.index, backwards, history.size()))
+        if backwards:
+            SublimeExternalCommandHistory.index = min(SublimeExternalCommandHistory.index + 1, history.size() - 1)
+        else:
+            SublimeExternalCommandHistory.index = max(SublimeExternalCommandHistory.index - 1, 0)
+
+        self.view.erase(edit, sublime.Region(0, self.view.size()))
+        self.view.insert(edit, 0, history.read()[SublimeExternalCommandHistory.index])
+
 
 class CancelledException(Exception):
     pass
@@ -218,12 +286,17 @@ class ExternalCommandBase(sublime_plugin.TextCommand):
         else:
             def start(cmdline):
                 if cmdline:
+                    history.add(cmdline)
                     self.command_manager.start_task(self, cmdline, **kwargs)
 
             if cmdline is not None:
                 start(cmdline)
             else:
-                self.view.window().show_input_panel('Command:', "", start, None, None)
+                panel = self.view.window().show_input_panel('Command:', history.getLast(), start, None, None)
+                panel.set_syntax_file('Packages/SublimeExternalCommand/external_command.hidden-tmLanguage')
+                panel.settings().set('is_widget', True)
+                panel.settings().set('gutter', False)
+                panel.settings().set('rulers', [])
 
 class FilterThroughCommandCommand(ExternalCommandBase):
     task_class = ReplaceTask


### PR DESCRIPTION
Hi, I've added history support to the ST3 version.  Use the UP/DOWN keys in the input box to retrieve previous commands.  The history is saved in ~/.sublimeexternalcommand_history.
